### PR TITLE
feat: FastConformer encoder forward (full pipeline) + transcribe wire-up

### DIFF
--- a/crates/fastconformer-core/src/encoder/attention.rs
+++ b/crates/fastconformer-core/src/encoder/attention.rs
@@ -1,0 +1,294 @@
+//! Multi-head relative-position attention (Transformer-XL style).
+//!
+//! Used by parakeet-tdt-0.6b-v3 (regular rel-pos) and the non-Longformer
+//! layers of any future Conformer. Longformer (local + global) is a
+//! follow-up — see [`AttentionType::RelPosLocalAttn`] in `config.rs`.
+//!
+//! Forward (one block):
+//!
+//! ```text
+//!   x_norm = LN(x)
+//!   Q = x_norm · W_q  + b_q     → [T, H, D]
+//!   K = x_norm · W_k             → [T, H, D]
+//!   V = x_norm · W_v  + b_v     → [T, H, D]
+//!
+//!   P = pos_emb_table · W_pos   → [2T-1, H, D]   // relative positions
+//!
+//!   AC = (Q + u_bias) · Kᵀ       per head        → [T, T]
+//!   BD = (Q + v_bias) · Pᵀ       per head        → [T, 2T-1]
+//!   BD' = rel_shift(BD)                          → [T, T]
+//!   score = (AC + BD') / sqrt(D)
+//!   attn  = softmax(score)
+//!   out_h = attn · V_h
+//!
+//!   out = concat(out_h) · W_o + b_o
+//!   x ← x + out
+//! ```
+
+use crate::encoder::ops::{layer_norm_rows, softmax_inplace};
+
+pub struct MultiHeadAttention {
+    pub d_model: usize,
+    pub n_heads: usize,
+    pub head_dim: usize,
+
+    // LN (γ, β each [d_model])
+    pub ln_gamma: Vec<f32>,
+    pub ln_beta: Vec<f32>,
+
+    // Q / K / V / out projections: each [d_model, d_model]
+    pub q_weight: Vec<f32>,
+    pub q_bias: Vec<f32>,
+    pub k_weight: Vec<f32>,
+    pub v_weight: Vec<f32>,
+    pub v_bias: Vec<f32>,
+    pub out_weight: Vec<f32>,
+    pub out_bias: Vec<f32>,
+
+    // Positional projection: [d_model, d_model]
+    pub pos_weight: Vec<f32>,
+
+    // Per-head learned position biases: each [n_heads, head_dim]
+    pub pos_bias_u: Vec<f32>,
+    pub pos_bias_v: Vec<f32>,
+}
+
+impl MultiHeadAttention {
+    /// Apply attention residual: `x ← x + MHA(x)`.
+    /// `x` is `[time, d_model]` row-major.
+    pub fn forward_residual(&self, x: &mut [f32], time: usize) {
+        let dm = self.d_model;
+        let h = self.n_heads;
+        let d = self.head_dim;
+        debug_assert_eq!(x.len(), time * dm);
+        debug_assert_eq!(d * h, dm);
+
+        // 1) LN on a copy.
+        let mut x_norm = x.to_vec();
+        layer_norm_rows(&mut x_norm, time, dm, &self.ln_gamma, &self.ln_beta, 1e-5);
+
+        // 2) Q, K, V projections.
+        let mut q = vec![0.0_f32; time * dm];
+        let mut k = vec![0.0_f32; time * dm];
+        let mut v = vec![0.0_f32; time * dm];
+        for t in 0..time {
+            let src = &x_norm[t * dm..(t + 1) * dm];
+            let qd = &mut q[t * dm..(t + 1) * dm];
+            qd.copy_from_slice(&self.q_bias);
+            mat_vec_add(&self.q_weight, src, qd, dm, dm);
+
+            let kd = &mut k[t * dm..(t + 1) * dm];
+            // K typically has no bias in NeMo; use zero if not present.
+            mat_vec_add(&self.k_weight, src, kd, dm, dm);
+
+            let vd = &mut v[t * dm..(t + 1) * dm];
+            vd.copy_from_slice(&self.v_bias);
+            mat_vec_add(&self.v_weight, src, vd, dm, dm);
+        }
+
+        // 3) Positional embeddings: build sinusoidal table of length 2T-1
+        //    for offsets [-(T-1) .. T-1], project through W_pos.
+        let pos_len = 2 * time - 1;
+        let pe_table = sinusoidal_pos_emb(pos_len, dm);
+        let mut pe_proj = vec![0.0_f32; pos_len * dm];
+        for i in 0..pos_len {
+            let src = &pe_table[i * dm..(i + 1) * dm];
+            let dst = &mut pe_proj[i * dm..(i + 1) * dm];
+            mat_vec_add(&self.pos_weight, src, dst, dm, dm);
+        }
+
+        // 4) Per-head computation.
+        let inv_sqrt_d = 1.0 / (d as f32).sqrt();
+        let mut output = vec![0.0_f32; time * dm];
+        let mut score = vec![0.0_f32; time]; // reused row buffer
+
+        for hd in 0..h {
+            // Slice helpers — closure-style indexing.
+            let q_h = |t: usize, c: usize| q[t * dm + hd * d + c];
+            let k_h = |t: usize, c: usize| k[t * dm + hd * d + c];
+            let v_h = |t: usize, c: usize| v[t * dm + hd * d + c];
+            let p_h = |i: usize, c: usize| pe_proj[i * dm + hd * d + c];
+            let u_h = |c: usize| self.pos_bias_u[hd * d + c];
+            let v_bias_h = |c: usize| self.pos_bias_v[hd * d + c];
+
+            // For each query frame t_q, compute scores against all t_k.
+            for t_q in 0..time {
+                // (Q + u) · Kᵀ : AC scores.
+                // (Q + v) · Pᵀ : BD scores at offsets [-(T-1) .. T-1].
+                // After rel_shift, BD' aligns offsets to time indices.
+                // We build score[t_k] directly without an explicit BD buffer.
+
+                // 1: AC[t_q, t_k] = Σ_c (Q[t_q,c] + u[c]) · K[t_k,c]
+                for t_k in 0..time {
+                    let mut s = 0.0_f32;
+                    for c in 0..d {
+                        s += (q_h(t_q, c) + u_h(c)) * k_h(t_k, c);
+                    }
+                    score[t_k] = s;
+                }
+
+                // 2: BD[t_q, off] = Σ_c (Q[t_q,c] + v[c]) · P[off, c]
+                //    where off ∈ [0..2T-1] corresponds to relative
+                //    position (off - (T-1)). The rel-shift trick maps
+                //    (off, t_q) → t_k = t_q - (off - (T-1)) and we want
+                //    score[t_k] += BD[t_q, off]. Equivalently, for each
+                //    t_k we pick off = (T-1) + t_q - t_k.
+                let mut bd_row = vec![0.0_f32; pos_len];
+                for off in 0..pos_len {
+                    let mut s = 0.0_f32;
+                    for c in 0..d {
+                        s += (q_h(t_q, c) + v_bias_h(c)) * p_h(off, c);
+                    }
+                    bd_row[off] = s;
+                }
+                for t_k in 0..time {
+                    let off = (time as isize - 1) + t_q as isize - t_k as isize;
+                    if (0..pos_len as isize).contains(&off) {
+                        score[t_k] += bd_row[off as usize];
+                    }
+                }
+
+                // 3: scale + softmax.
+                for s in score.iter_mut() {
+                    *s *= inv_sqrt_d;
+                }
+                softmax_inplace(&mut score);
+
+                // 4: out_h[t_q] = Σ_t_k attn[t_k] · V[t_k]
+                for c in 0..d {
+                    let mut s = 0.0_f32;
+                    for t_k in 0..time {
+                        s += score[t_k] * v_h(t_k, c);
+                    }
+                    output[t_q * dm + hd * d + c] = s;
+                }
+            }
+        }
+
+        // 5) Output projection.
+        let mut proj = vec![0.0_f32; time * dm];
+        for t in 0..time {
+            let src = &output[t * dm..(t + 1) * dm];
+            let dst = &mut proj[t * dm..(t + 1) * dm];
+            dst.copy_from_slice(&self.out_bias);
+            mat_vec_add(&self.out_weight, src, dst, dm, dm);
+        }
+
+        // 6) Residual.
+        for i in 0..time * dm {
+            x[i] += proj[i];
+        }
+    }
+}
+
+/// Build a sinusoidal positional embedding table of shape `[length, dim]`
+/// covering offsets centered on zero (length must be 2T-1; index 0
+/// corresponds to offset `-(T-1)`, index `length-1` to `T-1`).
+///
+/// Standard Transformer-XL formula:
+///   `pe[i, 2j]   = sin(off / 10000^(2j/dim))`
+///   `pe[i, 2j+1] = cos(off / 10000^(2j/dim))`
+/// where `off = i - (length / 2)`.
+fn sinusoidal_pos_emb(length: usize, dim: usize) -> Vec<f32> {
+    let mut out = vec![0.0_f32; length * dim];
+    let half = (length / 2) as i32;
+    for i in 0..length {
+        let off = i as i32 - half;
+        let off = off as f32;
+        for j in 0..dim / 2 {
+            let denom = 10000.0_f32.powf(2.0 * j as f32 / dim as f32);
+            let arg = off / denom;
+            out[i * dim + 2 * j] = arg.sin();
+            if 2 * j + 1 < dim {
+                out[i * dim + 2 * j + 1] = arg.cos();
+            }
+        }
+    }
+    out
+}
+
+/// `out += W · x` where W is `[rows, cols]` row-major.
+fn mat_vec_add(w: &[f32], x: &[f32], out: &mut [f32], rows: usize, cols: usize) {
+    debug_assert_eq!(w.len(), rows * cols);
+    debug_assert_eq!(x.len(), cols);
+    debug_assert_eq!(out.len(), rows);
+    for r in 0..rows {
+        let row = &w[r * cols..(r + 1) * cols];
+        let mut s = 0.0_f32;
+        for c in 0..cols {
+            s += row[c] * x[c];
+        }
+        out[r] += s;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn zero_mha(d_model: usize, n_heads: usize) -> MultiHeadAttention {
+        let head_dim = d_model / n_heads;
+        MultiHeadAttention {
+            d_model,
+            n_heads,
+            head_dim,
+            ln_gamma: vec![1.0; d_model],
+            ln_beta: vec![0.0; d_model],
+            q_weight: vec![0.0; d_model * d_model],
+            q_bias: vec![0.0; d_model],
+            k_weight: vec![0.0; d_model * d_model],
+            v_weight: vec![0.0; d_model * d_model],
+            v_bias: vec![0.0; d_model],
+            out_weight: vec![0.0; d_model * d_model],
+            out_bias: vec![0.0; d_model],
+            pos_weight: vec![0.0; d_model * d_model],
+            pos_bias_u: vec![0.0; n_heads * head_dim],
+            pos_bias_v: vec![0.0; n_heads * head_dim],
+        }
+    }
+
+    #[test]
+    fn zero_weights_keep_input_unchanged() {
+        let mha = zero_mha(4, 2);
+        let mut x = vec![1.0_f32, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]; // 2 × 4
+        let orig = x.clone();
+        mha.forward_residual(&mut x, 2);
+        // V=0 → output projection of zero → 0. Residual: x += 0.
+        for (a, b) in x.iter().zip(orig.iter()) {
+            assert!((a - b).abs() < 1e-5, "{a} vs {b}");
+        }
+    }
+
+    #[test]
+    fn out_bias_adds_constant_through_residual() {
+        let mut mha = zero_mha(4, 2);
+        mha.out_bias = vec![1.0, 2.0, 3.0, 4.0];
+        let mut x = vec![10.0, 20.0, 30.0, 40.0];
+        mha.forward_residual(&mut x, 1);
+        assert!((x[0] - 11.0).abs() < 1e-4);
+        assert!((x[1] - 22.0).abs() < 1e-4);
+        assert!((x[2] - 33.0).abs() < 1e-4);
+        assert!((x[3] - 44.0).abs() < 1e-4);
+    }
+
+    #[test]
+    fn sinusoidal_pos_emb_at_offset_zero_is_special() {
+        // At off=0: pe[..,2j]=sin(0)=0, pe[..,2j+1]=cos(0)=1.
+        let pe = sinusoidal_pos_emb(5, 4); // half = 2
+        // index 2 corresponds to off=0.
+        assert!((pe[2 * 4 + 0] - 0.0).abs() < 1e-6);
+        assert!((pe[2 * 4 + 1] - 1.0).abs() < 1e-6);
+        assert!((pe[2 * 4 + 2] - 0.0).abs() < 1e-6);
+        assert!((pe[2 * 4 + 3] - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn sinusoidal_pos_emb_is_symmetric_in_cos() {
+        // cos is even → pe[off, 2j+1] == pe[-off, 2j+1].
+        let pe = sinusoidal_pos_emb(7, 4); // half = 3
+        for j in 0..2 {
+            assert!((pe[(3 - 1) * 4 + 2 * j + 1] - pe[(3 + 1) * 4 + 2 * j + 1]).abs() < 1e-6);
+            assert!((pe[(3 - 2) * 4 + 2 * j + 1] - pe[(3 + 2) * 4 + 2 * j + 1]).abs() < 1e-6);
+        }
+    }
+}

--- a/crates/fastconformer-core/src/encoder/block.rs
+++ b/crates/fastconformer-core/src/encoder/block.rs
@@ -1,0 +1,46 @@
+//! Full Conformer block.
+//!
+//! ```text
+//! x ← x + 0.5 * FF1(x)         // macaron half
+//! x ← x + MHA(x)
+//! x ← x + ConvModule(x)
+//! x ← x + 0.5 * FF2(x)         // macaron half
+//! x ← LN_post(x)
+//! ```
+
+use crate::encoder::attention::MultiHeadAttention;
+use crate::encoder::conv_module::ConvModule;
+use crate::encoder::ff::FeedForward;
+use crate::encoder::ops::layer_norm_rows;
+
+pub struct ConformerBlock {
+    pub ff1: FeedForward,
+    pub attn: MultiHeadAttention,
+    pub conv: ConvModule,
+    pub ff2: FeedForward,
+    /// Final LayerNorm γ (length d_model).
+    pub ln_post_gamma: Vec<f32>,
+    /// Final LayerNorm β.
+    pub ln_post_beta: Vec<f32>,
+    pub d_model: usize,
+}
+
+impl ConformerBlock {
+    /// Apply the full block forward in place: `x ← block(x)`.
+    /// `x` is `[time, d_model]` row-major.
+    pub fn forward(&self, x: &mut [f32], time: usize) {
+        debug_assert_eq!(x.len(), time * self.d_model);
+        self.ff1.forward_residual(x, time);
+        self.attn.forward_residual(x, time);
+        self.conv.forward_residual(x, time);
+        self.ff2.forward_residual(x, time);
+        layer_norm_rows(
+            x,
+            time,
+            self.d_model,
+            &self.ln_post_gamma,
+            &self.ln_post_beta,
+            1e-5,
+        );
+    }
+}

--- a/crates/fastconformer-core/src/encoder/conv_module.rs
+++ b/crates/fastconformer-core/src/encoder/conv_module.rs
@@ -1,0 +1,233 @@
+//! Conformer convolution module.
+//!
+//! ```text
+//! x [T, d_model]
+//!   ↓ LayerNorm
+//!   ↓ Pointwise Conv1d (d_model → 2*d_model)
+//!   ↓ GLU (split last dim)
+//!   ↓ Depthwise Conv1d (kernel=conv_kernel_size, pad symmetric)
+//!   ↓ BatchNorm 1d (running stats)
+//!   ↓ Swish
+//!   ↓ Pointwise Conv1d (d_model → d_model)
+//!   = output [T, d_model]
+//! ```
+//!
+//! Pointwise Conv1d = batched linear per frame. Depthwise Conv1d means
+//! every output channel only mixes its own input channel along time.
+
+use crate::encoder::ops::{
+    batch_norm_1d_inference, glu_channels, layer_norm, linear, swish_inplace,
+};
+
+pub struct ConvModule {
+    pub d_model: usize,
+    pub conv_kernel_size: usize,
+
+    // LN (γ, β each [d_model])
+    pub ln_gamma: Vec<f32>,
+    pub ln_beta: Vec<f32>,
+
+    // Pointwise 1: [2*d_model, d_model]
+    pub pw1_weight: Vec<f32>,
+    pub pw1_bias: Vec<f32>,
+
+    // Depthwise: per-channel 1D kernel of length `conv_kernel_size`.
+    /// `[d_model, conv_kernel_size]` row-major (channel-major).
+    pub dw_weight: Vec<f32>,
+    pub dw_bias: Vec<f32>, // `[d_model]`
+
+    // BatchNorm running stats (γ, β, running_mean, running_var each [d_model])
+    pub bn_gamma: Vec<f32>,
+    pub bn_beta: Vec<f32>,
+    pub bn_running_mean: Vec<f32>,
+    pub bn_running_var: Vec<f32>,
+
+    // Pointwise 2: [d_model, d_model]
+    pub pw2_weight: Vec<f32>,
+    pub pw2_bias: Vec<f32>,
+}
+
+impl ConvModule {
+    /// Apply conv-module residual: `x ← x + ConvModule(x)`.
+    /// `x` is `[time, d_model]` row-major.
+    pub fn forward_residual(&self, x: &mut [f32], time: usize) {
+        let dm = self.d_model;
+        let dff = 2 * dm;
+        debug_assert_eq!(x.len(), time * dm);
+
+        // Side buffers.
+        let mut ln_buf = vec![0.0_f32; dm];
+        let mut pw1_out = vec![0.0_f32; dff];
+        let mut glu_out = vec![0.0_f32; time * dm]; // we need full time series before depthwise
+        let mut after_dw = vec![0.0_f32; time * dm];
+        let mut after_pw2 = vec![0.0_f32; time * dm];
+
+        // 1) LN + PW1 + GLU per frame → glu_out [time, dm]
+        for t in 0..time {
+            ln_buf.copy_from_slice(&x[t * dm..(t + 1) * dm]);
+            layer_norm(&mut ln_buf, &self.ln_gamma, &self.ln_beta, 1e-5);
+            linear(&self.pw1_weight, &self.pw1_bias, &ln_buf, &mut pw1_out);
+            glu_channels(&pw1_out, &mut glu_out[t * dm..(t + 1) * dm]);
+        }
+
+        // 2) Depthwise Conv1d along time for each channel. Symmetric
+        //    padding so output length = time.
+        depthwise_conv1d(
+            &glu_out,
+            time,
+            dm,
+            self.conv_kernel_size,
+            &self.dw_weight,
+            &self.dw_bias,
+            &mut after_dw,
+        );
+
+        // 3) BN + Swish (in place on after_dw).
+        batch_norm_1d_inference(
+            &mut after_dw,
+            time,
+            dm,
+            &self.bn_gamma,
+            &self.bn_beta,
+            &self.bn_running_mean,
+            &self.bn_running_var,
+            1e-5,
+        );
+        swish_inplace(&mut after_dw);
+
+        // 4) Pointwise 2 per frame.
+        for t in 0..time {
+            let src = &after_dw[t * dm..(t + 1) * dm];
+            linear(
+                &self.pw2_weight,
+                &self.pw2_bias,
+                src,
+                &mut after_pw2[t * dm..(t + 1) * dm],
+            );
+        }
+
+        // 5) Residual.
+        for i in 0..time * dm {
+            x[i] += after_pw2[i];
+        }
+    }
+}
+
+/// Depthwise 1D convolution with symmetric "same" padding.
+/// `x` is `[time, channels]` row-major. `weight` is `[channels, kernel]`.
+/// Output is `[time, channels]` row-major. `bias` is `[channels]`.
+fn depthwise_conv1d(
+    x: &[f32],
+    time: usize,
+    channels: usize,
+    kernel: usize,
+    weight: &[f32],
+    bias: &[f32],
+    out: &mut [f32],
+) {
+    debug_assert_eq!(x.len(), time * channels);
+    debug_assert_eq!(weight.len(), channels * kernel);
+    debug_assert_eq!(bias.len(), channels);
+    debug_assert_eq!(out.len(), time * channels);
+
+    let pad = kernel / 2;
+    for t in 0..time {
+        for c in 0..channels {
+            let kw = &weight[c * kernel..(c + 1) * kernel];
+            let mut s = bias[c];
+            for k in 0..kernel {
+                let src_t = t as isize + k as isize - pad as isize;
+                if src_t < 0 || src_t >= time as isize {
+                    continue;
+                }
+                s += x[src_t as usize * channels + c] * kw[k];
+            }
+            out[t * channels + c] = s;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn zero_conv_module(d_model: usize, kernel: usize) -> ConvModule {
+        ConvModule {
+            d_model,
+            conv_kernel_size: kernel,
+            ln_gamma: vec![1.0; d_model],
+            ln_beta: vec![0.0; d_model],
+            pw1_weight: vec![0.0; 2 * d_model * d_model],
+            pw1_bias: vec![0.0; 2 * d_model],
+            dw_weight: vec![0.0; d_model * kernel],
+            dw_bias: vec![0.0; d_model],
+            bn_gamma: vec![1.0; d_model],
+            bn_beta: vec![0.0; d_model],
+            bn_running_mean: vec![0.0; d_model],
+            bn_running_var: vec![1.0; d_model],
+            pw2_weight: vec![0.0; d_model * d_model],
+            pw2_bias: vec![0.0; d_model],
+        }
+    }
+
+    #[test]
+    fn zero_weights_keep_input_unchanged() {
+        let cm = zero_conv_module(4, 3);
+        let mut x = vec![1.0_f32, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]; // 2 frames × 4
+        let orig = x.clone();
+        cm.forward_residual(&mut x, 2);
+        // PW1=0 → GLU(0) = 0 → DW = bias = 0 → BN(0) = -mean/std + β = 0
+        // Wait: BN of [0..0] with running_mean=0, var=1 → (0-0)*1 + 0 = 0
+        // Swish(0)=0, PW2(0) + bias(0) = 0. Residual: x += 0.
+        for (a, b) in x.iter().zip(orig.iter()) {
+            assert!((a - b).abs() < 1e-5, "{a} vs {b}");
+        }
+    }
+
+    #[test]
+    fn pw2_bias_adds_constant() {
+        let mut cm = zero_conv_module(3, 3);
+        cm.pw2_bias = vec![1.0, 2.0, 3.0];
+        // After zero PW1 → 0 → GLU(0) = 0 → DW(0)+0_bias = 0 → BN(0)=0 →
+        // Swish(0)=0 → PW2(0)+bias = bias. So residual adds bias.
+        let mut x = vec![10.0, 20.0, 30.0];
+        cm.forward_residual(&mut x, 1);
+        assert!((x[0] - 11.0).abs() < 1e-5);
+        assert!((x[1] - 22.0).abs() < 1e-5);
+        assert!((x[2] - 33.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn depthwise_conv1d_identity_kernel_passes_through() {
+        // 1 channel, kernel=3, weights=[0,1,0] → output[t] = input[t].
+        let x = vec![1.0_f32, 2.0, 3.0, 4.0];
+        let weight = vec![0.0, 1.0, 0.0];
+        let bias = vec![0.0];
+        let mut out = vec![0.0; 4];
+        depthwise_conv1d(&x, 4, 1, 3, &weight, &bias, &mut out);
+        assert_eq!(out, vec![1.0, 2.0, 3.0, 4.0]);
+    }
+
+    #[test]
+    fn depthwise_conv1d_pads_symmetrically() {
+        // 1 channel, kernel=3, weights=[1,0,0] → output[t] = input[t-1]
+        // (left padding = zero for t=0).
+        let x = vec![1.0_f32, 2.0, 3.0];
+        let weight = vec![1.0, 0.0, 0.0];
+        let bias = vec![0.0];
+        let mut out = vec![0.0; 3];
+        depthwise_conv1d(&x, 3, 1, 3, &weight, &bias, &mut out);
+        assert_eq!(out, vec![0.0, 1.0, 2.0]);
+    }
+
+    #[test]
+    fn depthwise_conv1d_two_channels_independent() {
+        // 2 channels, each with identity kernel.
+        let x = vec![1.0_f32, 10.0, 2.0, 20.0, 3.0, 30.0]; // [t, c]
+        let weight = vec![0.0, 1.0, 0.0,   0.0, 1.0, 0.0]; // 2 channels × 3
+        let bias = vec![0.0, 0.0];
+        let mut out = vec![0.0; 6];
+        depthwise_conv1d(&x, 3, 2, 3, &weight, &bias, &mut out);
+        assert_eq!(out, vec![1.0, 10.0, 2.0, 20.0, 3.0, 30.0]);
+    }
+}

--- a/crates/fastconformer-core/src/encoder/ff.rs
+++ b/crates/fastconformer-core/src/encoder/ff.rs
@@ -1,0 +1,107 @@
+//! Conformer feed-forward "macaron" half.
+//!
+//! Each Conformer block has two FF halves wrapping the attention + conv
+//! modules. The output is scaled by 0.5 (the macaron coefficient) before
+//! the residual add.
+//!
+//! ```text
+//! y = LN(x) → fc1 → swish → fc2 → 0.5 * y
+//! ```
+//!
+//! `fc1` expands `d_model → 4 * d_model`, `fc2` projects back to `d_model`.
+
+use crate::encoder::ops::{layer_norm, linear, swish_inplace};
+
+/// Weights for one FF macaron half.
+pub struct FeedForward {
+    /// `[d_model]`
+    pub ln_gamma: Vec<f32>,
+    /// `[d_model]`
+    pub ln_beta: Vec<f32>,
+    /// `[4 * d_model, d_model]`
+    pub fc1_weight: Vec<f32>,
+    /// `[4 * d_model]`
+    pub fc1_bias: Vec<f32>,
+    /// `[d_model, 4 * d_model]`
+    pub fc2_weight: Vec<f32>,
+    /// `[d_model]`
+    pub fc2_bias: Vec<f32>,
+    pub d_model: usize,
+}
+
+impl FeedForward {
+    /// Apply one macaron half-residual step in place: `x ← x + 0.5 * FF(x)`.
+    /// `x` is `[time, d_model]` row-major.
+    pub fn forward_residual(&self, x: &mut [f32], time: usize) {
+        debug_assert_eq!(x.len(), time * self.d_model);
+        let dm = self.d_model;
+        let dff = 4 * dm;
+        let mut buf = vec![0.0_f32; dm];
+        let mut hidden = vec![0.0_f32; dff];
+        for t in 0..time {
+            // Copy frame, layer-normalize on a side buffer (we add 0.5 *
+            // FF(LN(x)) to the *original* x, not LN(x)).
+            buf.copy_from_slice(&x[t * dm..(t + 1) * dm]);
+            layer_norm(&mut buf, &self.ln_gamma, &self.ln_beta, 1e-5);
+            // fc1: [d_model] → [4*d_model]
+            linear(&self.fc1_weight, &self.fc1_bias, &buf, &mut hidden);
+            swish_inplace(&mut hidden);
+            // fc2: [4*d_model] → [d_model]
+            linear(&self.fc2_weight, &self.fc2_bias, &hidden, &mut buf);
+            // Residual with 0.5 macaron scale.
+            for c in 0..dm {
+                x[t * dm + c] += 0.5 * buf[c];
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn identity_ff(d_model: usize) -> FeedForward {
+        let dff = 4 * d_model;
+        // Layer norm: γ=1, β=0 (identity-like after normalization).
+        let ln_gamma = vec![1.0; d_model];
+        let ln_beta = vec![0.0; d_model];
+        // fc1 zero → output zero → swish(0) = 0 → fc2 zero → 0
+        let fc1_weight = vec![0.0; dff * d_model];
+        let fc1_bias = vec![0.0; dff];
+        let fc2_weight = vec![0.0; d_model * dff];
+        let fc2_bias = vec![0.0; d_model];
+        FeedForward {
+            ln_gamma,
+            ln_beta,
+            fc1_weight,
+            fc1_bias,
+            fc2_weight,
+            fc2_bias,
+            d_model,
+        }
+    }
+
+    #[test]
+    fn zero_weights_keep_input_unchanged() {
+        let ff = identity_ff(4);
+        let mut x = vec![1.0_f32, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]; // 2 frames × 4
+        let original = x.clone();
+        ff.forward_residual(&mut x, 2);
+        // FF(x) = 0 → residual leaves x unchanged.
+        for (a, b) in x.iter().zip(original.iter()) {
+            assert!((a - b).abs() < 1e-6, "expected unchanged, {a} vs {b}");
+        }
+    }
+
+    #[test]
+    fn nonzero_bias_adds_constant_through_residual() {
+        // Set fc2 bias only — output is then 0.5 * fc2_bias added to x.
+        let mut ff = identity_ff(3);
+        ff.fc2_bias = vec![2.0, 4.0, 6.0]; // 0.5 × bias = [1, 2, 3]
+        let mut x = vec![10.0, 20.0, 30.0]; // 1 frame
+        ff.forward_residual(&mut x, 1);
+        assert!((x[0] - 11.0).abs() < 1e-5);
+        assert!((x[1] - 22.0).abs() < 1e-5);
+        assert!((x[2] - 33.0).abs() < 1e-5);
+    }
+}

--- a/crates/fastconformer-core/src/encoder/mod.rs
+++ b/crates/fastconformer-core/src/encoder/mod.rs
@@ -1,31 +1,242 @@
-//! FastConformer encoder building blocks.
+//! FastConformer encoder.
 //!
-//! This module hosts the f32 reference implementation of the encoder.
-//! It will eventually be backed by ggml graphs (CPU/CUDA/Metal/Vulkan)
-//! and QNN/NNAPI graphs for the NPU hot path. Today, the goal is to
-//! have a correct CPU forward that matches NeMo numerics within ~1e-3
-//! per layer, validated by `tests/layer_reference.rs`.
-//!
-//! ## Module map
+//! Forward path:
 //! ```text
-//! ops.rs        — primitive ops (matvec, linear, layer_norm, swish, GLU,
-//!                 softmax, batch_norm)
-//! subsample.rs  — striding conv2d ×8 (TODO)
-//! attention.rs  — multi-head rel-pos with optional Longformer (TODO)
-//! conv_module.rs — pointwise / depthwise / GLU / batch_norm (TODO)
-//! ff.rs         — feed-forward macaron half (TODO)
-//! block.rs      — full Conformer block (TODO)
+//!   mel [T, n_mels]
+//!     ↓ subsample (Conv2d ×3 stride 2 + Linear)
+//!   feat [T/8, d_model]
+//!     ↓ block × n_layers   (FF1 → MHA → Conv → FF2 → LN_post)
+//!   enc  [T/8, d_model]
 //! ```
 //!
 //! ## Status
-//! ops.rs is complete and unit-tested. The remaining modules are
-//! scaffolded as stubs — they have the type signatures the rest of the
-//! codebase will rely on, but their forward methods return
-//! `NotImplemented`. Each carries a TODO list of what's left to wire.
+//! Pure-Rust f32 forward. Produces shape-correct outputs from any GGUF
+//! that follows the converter's tensor naming. Numerical equivalence
+//! against NeMo is validated via `tests/layer_reference.rs` once
+//! reference fixtures are present.
+//!
+//! ## NPU offload (future)
+//! Each block's attention and conv MatMuls can be replaced by
+//! qnn-backend / nnapi-backend graphs with the same input/output shape.
+//! The composition logic in [`FastConformerEncoder::forward`] stays.
 
+pub mod attention;
+pub mod block;
+pub mod conv_module;
+pub mod ff;
 pub mod ops;
+pub mod subsample;
 
 pub use ops::{
     batch_norm_1d_inference, glu_channels, layer_norm, layer_norm_rows, linear, matvec_add,
     softmax_inplace, swish_inplace,
 };
+
+use crate::config::{AttentionType, Config};
+pub use attention::MultiHeadAttention;
+pub use block::ConformerBlock;
+pub use conv_module::ConvModule;
+pub use ff::FeedForward;
+pub use subsample::{subsampled_mel_dim, subsampled_time_dim, Subsample};
+
+/// Output of the encoder forward pass.
+#[derive(Debug)]
+pub struct EncoderOutput {
+    pub data: Vec<f32>,
+    pub n_frames: usize,
+    pub d_model: usize,
+}
+
+/// Full FastConformer encoder.
+pub struct FastConformerEncoder {
+    pub cfg: Config,
+    pub subsample: Subsample,
+    pub blocks: Vec<ConformerBlock>,
+    /// Final LayerNorm γ over the last block's output (length d_model).
+    pub ln_post_gamma: Vec<f32>,
+    pub ln_post_beta: Vec<f32>,
+}
+
+impl FastConformerEncoder {
+    /// Run the encoder on a `[time, n_mels]` mel spectrogram.
+    pub fn forward(&self, mel: &[f32], n_frames: usize) -> Result<EncoderOutput, String> {
+        let dm = self.cfg.d_model as usize;
+        if self.cfg.attention_type == AttentionType::RelPosLocalAttn {
+            // TODO: Longformer (local + global) attention. Until that's
+            // wired, callers using ReazonSpeech will get an early error
+            // here rather than silently using vanilla attention.
+            return Err(
+                "FastConformerEncoder: Longformer attention not yet implemented; \
+                 only AttentionType::RelPos is supported in this build"
+                    .into(),
+            );
+        }
+
+        // 1) Subsample.
+        let (mut x, t_out) = self.subsample.forward(mel, n_frames);
+
+        // 2) N Conformer blocks.
+        for block in &self.blocks {
+            block.forward(&mut x, t_out);
+        }
+
+        // 3) Final LN.
+        layer_norm_rows(&mut x, t_out, dm, &self.ln_post_gamma, &self.ln_post_beta, 1e-5);
+
+        Ok(EncoderOutput {
+            data: x,
+            n_frames: t_out,
+            d_model: dm,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn zero_block(d_model: usize, n_heads: usize, conv_kernel: usize) -> ConformerBlock {
+        ConformerBlock {
+            ff1: FeedForward {
+                ln_gamma: vec![1.0; d_model],
+                ln_beta: vec![0.0; d_model],
+                fc1_weight: vec![0.0; 4 * d_model * d_model],
+                fc1_bias: vec![0.0; 4 * d_model],
+                fc2_weight: vec![0.0; d_model * 4 * d_model],
+                fc2_bias: vec![0.0; d_model],
+                d_model,
+            },
+            attn: MultiHeadAttention {
+                d_model,
+                n_heads,
+                head_dim: d_model / n_heads,
+                ln_gamma: vec![1.0; d_model],
+                ln_beta: vec![0.0; d_model],
+                q_weight: vec![0.0; d_model * d_model],
+                q_bias: vec![0.0; d_model],
+                k_weight: vec![0.0; d_model * d_model],
+                v_weight: vec![0.0; d_model * d_model],
+                v_bias: vec![0.0; d_model],
+                out_weight: vec![0.0; d_model * d_model],
+                out_bias: vec![0.0; d_model],
+                pos_weight: vec![0.0; d_model * d_model],
+                pos_bias_u: vec![0.0; n_heads * (d_model / n_heads)],
+                pos_bias_v: vec![0.0; n_heads * (d_model / n_heads)],
+            },
+            conv: ConvModule {
+                d_model,
+                conv_kernel_size: conv_kernel,
+                ln_gamma: vec![1.0; d_model],
+                ln_beta: vec![0.0; d_model],
+                pw1_weight: vec![0.0; 2 * d_model * d_model],
+                pw1_bias: vec![0.0; 2 * d_model],
+                dw_weight: vec![0.0; d_model * conv_kernel],
+                dw_bias: vec![0.0; d_model],
+                bn_gamma: vec![1.0; d_model],
+                bn_beta: vec![0.0; d_model],
+                bn_running_mean: vec![0.0; d_model],
+                bn_running_var: vec![1.0; d_model],
+                pw2_weight: vec![0.0; d_model * d_model],
+                pw2_bias: vec![0.0; d_model],
+            },
+            ff2: FeedForward {
+                ln_gamma: vec![1.0; d_model],
+                ln_beta: vec![0.0; d_model],
+                fc1_weight: vec![0.0; 4 * d_model * d_model],
+                fc1_bias: vec![0.0; 4 * d_model],
+                fc2_weight: vec![0.0; d_model * 4 * d_model],
+                fc2_bias: vec![0.0; d_model],
+                d_model,
+            },
+            ln_post_gamma: vec![1.0; d_model],
+            ln_post_beta: vec![0.0; d_model],
+            d_model,
+        }
+    }
+
+    #[test]
+    fn zero_encoder_produces_finite_output_with_correct_shape() {
+        // Tiny config: 4 mels, 8 d_model, 1 layer, 2 heads.
+        let mut cfg = Config::dummy_parakeet_tdt_v3();
+        cfg.feat_in = 8;
+        cfg.n_mels = 8;
+        cfg.d_model = 8;
+        cfg.n_layers = 1;
+        cfg.n_heads = 2;
+        cfg.conv_kernel_size = 3;
+
+        let n_mels_out = subsampled_mel_dim(8); // 8→4→2→1 = 1
+        let channels = 8;
+        let feat_per_step = channels * n_mels_out;
+
+        let subsample = Subsample {
+            n_mels: 8,
+            d_model: 8,
+            n_mels_out,
+            channels,
+            conv0_weight: vec![0.0; channels * 1 * 9],
+            conv0_bias: vec![0.0; channels],
+            conv1_weight: vec![0.0; channels * channels * 9],
+            conv1_bias: vec![0.0; channels],
+            conv2_weight: vec![0.0; channels * channels * 9],
+            conv2_bias: vec![0.0; channels],
+            out_weight: vec![0.0; 8 * feat_per_step],
+            out_bias: vec![0.0; 8],
+        };
+
+        let blocks = vec![zero_block(8, 2, 3)];
+        let enc = FastConformerEncoder {
+            cfg,
+            subsample,
+            blocks,
+            ln_post_gamma: vec![1.0; 8],
+            ln_post_beta: vec![0.0; 8],
+        };
+
+        let mel = vec![0.0_f32; 16 * 8];
+        let out = enc.forward(&mel, 16).unwrap();
+        assert_eq!(out.d_model, 8);
+        assert_eq!(out.n_frames, subsampled_time_dim(16));
+        assert_eq!(out.data.len(), out.n_frames * out.d_model);
+        for v in &out.data {
+            assert!(v.is_finite());
+        }
+    }
+
+    #[test]
+    fn longformer_attention_returns_clear_error() {
+        let mut cfg = Config::dummy_reazonspeech_nemo_v2();
+        cfg.n_layers = 0; // skip any block work
+        cfg.feat_in = 8;
+        cfg.n_mels = 8;
+        cfg.d_model = 8;
+
+        let n_mels_out = subsampled_mel_dim(8);
+        let channels = 8;
+        let feat_per_step = channels * n_mels_out;
+        let subsample = Subsample {
+            n_mels: 8,
+            d_model: 8,
+            n_mels_out,
+            channels,
+            conv0_weight: vec![0.0; channels * 9],
+            conv0_bias: vec![0.0; channels],
+            conv1_weight: vec![0.0; channels * channels * 9],
+            conv1_bias: vec![0.0; channels],
+            conv2_weight: vec![0.0; channels * channels * 9],
+            conv2_bias: vec![0.0; channels],
+            out_weight: vec![0.0; 8 * feat_per_step],
+            out_bias: vec![0.0; 8],
+        };
+        let enc = FastConformerEncoder {
+            cfg,
+            subsample,
+            blocks: vec![],
+            ln_post_gamma: vec![1.0; 8],
+            ln_post_beta: vec![0.0; 8],
+        };
+        let mel = vec![0.0_f32; 16 * 8];
+        let err = enc.forward(&mel, 16).unwrap_err();
+        assert!(err.contains("Longformer"), "got: {err}");
+    }
+}

--- a/crates/fastconformer-core/src/encoder/subsample.rs
+++ b/crates/fastconformer-core/src/encoder/subsample.rs
@@ -1,0 +1,284 @@
+//! Striding Conv2d subsampling stack.
+//!
+//! NeMo Conformer's `subsampling="striding"` does three Conv2d stages
+//! (kernel=3, stride=2, pad=1) interleaved with ReLU, then a final
+//! Linear that projects the flattened [intermediate, mel/8] feature map
+//! down to `d_model`.
+//!
+//! Input shape  : `[time, n_mels]` row-major.
+//! Output shape : `[time/8, d_model]` row-major.
+//!
+//! For typical 16 kHz / 80-mel input, the mel axis goes 80 → 40 → 20 → 10.
+//! The intermediate channel count `C` is configurable but standard NeMo
+//! uses `C = d_model` so the final feature map is `[d_model, time/8, 10]`,
+//! which is then flattened to `[time/8, d_model * 10]` and projected by
+//! the Linear back to `[time/8, d_model]`.
+
+/// Subsampling weights.
+pub struct Subsample {
+    pub n_mels: usize,
+    pub d_model: usize,
+    /// Output mel dim after 3 stages of stride-2 (≈ n_mels / 8, ceil semantics).
+    pub n_mels_out: usize,
+
+    /// `[C, 1, 3, 3]` flattened: out_channels × in_channels × kh × kw.
+    pub conv0_weight: Vec<f32>,
+    pub conv0_bias: Vec<f32>,
+    /// `[C, C, 3, 3]`
+    pub conv1_weight: Vec<f32>,
+    pub conv1_bias: Vec<f32>,
+    /// `[C, C, 3, 3]`
+    pub conv2_weight: Vec<f32>,
+    pub conv2_bias: Vec<f32>,
+    /// Intermediate channel count (`C`).
+    pub channels: usize,
+
+    /// Final linear: `[d_model, channels * n_mels_out]`
+    pub out_weight: Vec<f32>,
+    pub out_bias: Vec<f32>,
+}
+
+impl Subsample {
+    /// Apply subsampling to a `[time, n_mels]` mel spectrogram.
+    /// Returns a `[time_out, d_model]` flat row-major buffer plus the
+    /// time count.
+    pub fn forward(&self, mel: &[f32], time: usize) -> (Vec<f32>, usize) {
+        debug_assert_eq!(mel.len(), time * self.n_mels);
+
+        // Stage 0: 1 → C, mel: n_mels → n_mels/2 (ceil), time → time/2 (ceil).
+        let (mut buf, t1, h1) = conv2d_stride2(
+            mel,
+            1,
+            time,
+            self.n_mels,
+            self.channels,
+            &self.conv0_weight,
+            &self.conv0_bias,
+        );
+        relu(&mut buf);
+
+        // Stage 1: C → C, half again.
+        let (mut buf, t2, h2) = conv2d_stride2(
+            &buf,
+            self.channels,
+            t1,
+            h1,
+            self.channels,
+            &self.conv1_weight,
+            &self.conv1_bias,
+        );
+        relu(&mut buf);
+
+        // Stage 2: C → C, half again.
+        let (buf, t3, h3) = conv2d_stride2(
+            &buf,
+            self.channels,
+            t2,
+            h2,
+            self.channels,
+            &self.conv2_weight,
+            &self.conv2_bias,
+        );
+
+        debug_assert_eq!(h3, self.n_mels_out, "mel-axis dim mismatch after subsample");
+
+        // Flatten: [C, T_out, mel_out] → [T_out, C * mel_out] row-major.
+        // Source layout from conv2d_stride2 is `[C, T_out, mel_out]`.
+        let feat_per_step = self.channels * h3;
+        let mut flat = vec![0.0_f32; t3 * feat_per_step];
+        for c in 0..self.channels {
+            for t in 0..t3 {
+                for h in 0..h3 {
+                    let src = c * t3 * h3 + t * h3 + h;
+                    let dst = t * feat_per_step + c * h3 + h;
+                    flat[dst] = buf[src];
+                }
+            }
+        }
+
+        // Final Linear: per-step [C * mel_out] → [d_model].
+        let mut out = vec![0.0_f32; t3 * self.d_model];
+        for t in 0..t3 {
+            let src = &flat[t * feat_per_step..(t + 1) * feat_per_step];
+            let dst = &mut out[t * self.d_model..(t + 1) * self.d_model];
+            // dst = bias + W @ src
+            dst.copy_from_slice(&self.out_bias);
+            for r in 0..self.d_model {
+                let row = &self.out_weight[r * feat_per_step..(r + 1) * feat_per_step];
+                let mut s = 0.0_f32;
+                for c in 0..feat_per_step {
+                    s += row[c] * src[c];
+                }
+                dst[r] += s;
+            }
+        }
+
+        (out, t3)
+    }
+}
+
+fn relu(x: &mut [f32]) {
+    for v in x.iter_mut() {
+        if *v < 0.0 {
+            *v = 0.0;
+        }
+    }
+}
+
+/// Conv2d with kernel=3, stride=2, pad=1.
+///
+/// Input layout : `[in_c, H, W]` row-major.
+/// Weight layout: `[out_c, in_c, 3, 3]` row-major.
+/// Output layout: `[out_c, H_out, W_out]` row-major.
+///
+/// Returns (output_buffer, H_out, W_out).
+fn conv2d_stride2(
+    input: &[f32],
+    in_c: usize,
+    h_in: usize,
+    w_in: usize,
+    out_c: usize,
+    weight: &[f32],
+    bias: &[f32],
+) -> (Vec<f32>, usize, usize) {
+    let kh = 3;
+    let kw = 3;
+    let stride = 2;
+    let pad = 1;
+    let h_out = (h_in + 2 * pad - kh) / stride + 1;
+    let w_out = (w_in + 2 * pad - kw) / stride + 1;
+    debug_assert_eq!(input.len(), in_c * h_in * w_in);
+    debug_assert_eq!(weight.len(), out_c * in_c * kh * kw);
+    debug_assert_eq!(bias.len(), out_c);
+
+    let mut out = vec![0.0_f32; out_c * h_out * w_out];
+
+    for oc in 0..out_c {
+        for h_o in 0..h_out {
+            for w_o in 0..w_out {
+                let mut s = bias[oc];
+                let h_origin = h_o as isize * stride as isize - pad as isize;
+                let w_origin = w_o as isize * stride as isize - pad as isize;
+                for ic in 0..in_c {
+                    let w_base = ((oc * in_c + ic) * kh) * kw;
+                    for ki in 0..kh {
+                        let h_in_idx = h_origin + ki as isize;
+                        if h_in_idx < 0 || h_in_idx >= h_in as isize {
+                            continue;
+                        }
+                        for kj in 0..kw {
+                            let w_in_idx = w_origin + kj as isize;
+                            if w_in_idx < 0 || w_in_idx >= w_in as isize {
+                                continue;
+                            }
+                            let in_off = (ic * h_in + h_in_idx as usize) * w_in
+                                + w_in_idx as usize;
+                            let w_off = w_base + ki * kw + kj;
+                            s += input[in_off] * weight[w_off];
+                        }
+                    }
+                }
+                out[(oc * h_out + h_o) * w_out + w_o] = s;
+            }
+        }
+    }
+    (out, h_out, w_out)
+}
+
+/// Compute the output mel dimension after 3 stages of stride-2.
+pub fn subsampled_mel_dim(n_mels: usize) -> usize {
+    let pad = 1;
+    let kh = 3;
+    let stride = 2;
+    let mut h = n_mels;
+    for _ in 0..3 {
+        h = (h + 2 * pad - kh) / stride + 1;
+    }
+    h
+}
+
+/// Compute the output time dimension after 3 stages of stride-2.
+pub fn subsampled_time_dim(time: usize) -> usize {
+    subsampled_mel_dim(time) // same arithmetic
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn subsampled_dims_match_factor_8_for_typical_inputs() {
+        // 80 mel → 40 → 20 → 10.
+        assert_eq!(subsampled_mel_dim(80), 10);
+        // 1600 frames → 800 → 400 → 200 (close to time/8).
+        assert_eq!(subsampled_time_dim(1600), 200);
+    }
+
+    #[test]
+    fn conv2d_zero_weight_returns_bias_planes() {
+        // 1 input channel, 1 output channel, all-zero weight, bias=2.
+        // Output = bias plane (size H_out × W_out).
+        // (2 + 2 - 3) / 2 + 1 = 1. So h_out=w_out=1.
+        let input = vec![1.0_f32, 2.0, 3.0, 4.0]; // 2x2
+        let weight = vec![0.0; 9]; // 1*1*3*3
+        let bias = vec![2.0];
+        let (out, h_out, w_out) = conv2d_stride2(&input, 1, 2, 2, 1, &weight, &bias);
+        assert_eq!(h_out, 1);
+        assert_eq!(w_out, 1);
+        assert_eq!(out, vec![2.0]);
+    }
+
+    #[test]
+    fn conv2d_unit_weight_at_center_is_pixel_pick() {
+        // 1 in, 1 out, weight = [[0,0,0],[0,1,0],[0,0,0]] picks the
+        // center pixel of each receptive field. With stride=2 pad=1 on a
+        // 4×4 input the center of (h_o=0, w_o=0) lands at (h=0, w=0),
+        // (h_o=1, w_o=0) → (h=2, w=0), etc.
+        let input = vec![
+            1.0_f32, 2.0, 3.0, 4.0,
+            5.0, 6.0, 7.0, 8.0,
+            9.0, 10.0, 11.0, 12.0,
+            13.0, 14.0, 15.0, 16.0,
+        ];
+        let mut weight = vec![0.0_f32; 9];
+        weight[4] = 1.0; // center of the 3x3 kernel
+        let bias = vec![0.0];
+        let (out, h_out, w_out) = conv2d_stride2(&input, 1, 4, 4, 1, &weight, &bias);
+        assert_eq!(h_out, 2);
+        assert_eq!(w_out, 2);
+        // Picks (0,0), (0,2), (2,0), (2,2) → 1, 3, 9, 11.
+        assert_eq!(out, vec![1.0, 3.0, 9.0, 11.0]);
+    }
+
+    #[test]
+    fn subsample_zero_weights_returns_bias_only() {
+        let n_mels = 8;
+        let d_model = 4;
+        let n_mels_out = subsampled_mel_dim(n_mels); // (8→4→2→1) = 1
+        let channels = 4;
+        let feat_per_step = channels * n_mels_out;
+        let s = Subsample {
+            n_mels,
+            d_model,
+            n_mels_out,
+            channels,
+            conv0_weight: vec![0.0; channels * 1 * 3 * 3],
+            conv0_bias: vec![0.0; channels],
+            conv1_weight: vec![0.0; channels * channels * 3 * 3],
+            conv1_bias: vec![0.0; channels],
+            conv2_weight: vec![0.0; channels * channels * 3 * 3],
+            conv2_bias: vec![0.0; channels],
+            out_weight: vec![0.0; d_model * feat_per_step],
+            out_bias: vec![1.0; d_model],
+        };
+        // 16 frames in → 16 → 8 → 4 → 2 (after 3 stride-2). t_out = 2.
+        let mel = vec![0.0_f32; 16 * n_mels];
+        let (out, t_out) = s.forward(&mel, 16);
+        assert_eq!(t_out, 2);
+        assert_eq!(out.len(), 2 * d_model);
+        // All outputs equal out_bias.
+        for v in &out {
+            assert!((v - 1.0).abs() < 1e-6);
+        }
+    }
+}

--- a/crates/parakeet-backend/src/decoder.rs
+++ b/crates/parakeet-backend/src/decoder.rs
@@ -32,9 +32,8 @@
 //! Reference: arxiv 2304.06795 "Token-and-Duration Transducer for ASR".
 
 use fastconformer_core::Config;
+use fastconformer_core::encoder::EncoderOutput;
 use gguf_loader::GgufFile;
-
-use crate::encoder::EncoderOutput;
 
 /// One LSTM layer.
 struct LstmLayer {

--- a/crates/parakeet-backend/src/encoder.rs
+++ b/crates/parakeet-backend/src/encoder.rs
@@ -1,36 +1,148 @@
-//! FastConformer encoder (rel-pos attention, no Longformer).
+//! Parakeet encoder wrapper.
 //!
-//! Shared shape with `reazonspeech-backend::encoder` — only the attention
-//! variant differs. Future cleanup: extract the encoder body into
-//! `fastconformer-core` once both crates have a working forward.
-//!
-//! ## Status
-//! Stub. See `reazonspeech-backend/src/encoder.rs` for the parallel
-//! TODO list — most of the work transfers here unchanged.
+//! Same loader logic as reazonspeech-backend — pulls
+//! `enc.{subsample,block.L.*,ln_post}.*` tensors and constructs the
+//! shared `fastconformer_core::FastConformerEncoder`. Difference vs
+//! reazonspeech is the encoder config: vanilla rel-pos attention, no
+//! Longformer, vocab=8192.
 
-use fastconformer_core::{Config, MelSpectrogram};
+use fastconformer_core::encoder::{
+    ConformerBlock, ConvModule, FastConformerEncoder, FeedForward, MultiHeadAttention,
+    Subsample, subsampled_mel_dim,
+};
+pub use fastconformer_core::encoder::EncoderOutput;
+use fastconformer_core::Config;
+use gguf_loader::GgufFile;
 
-/// Encoder output: `[n_frames_after_subsample, d_model]` row-major f32.
-pub struct EncoderOutput {
-    pub data: Vec<f32>,
-    pub n_frames: usize,
-    pub d_model: usize,
+pub fn load(gguf: &GgufFile, cfg: Config) -> Result<FastConformerEncoder, String> {
+    let dm = cfg.d_model as usize;
+    let n_heads = cfg.n_heads as usize;
+    let conv_kernel = cfg.conv_kernel_size as usize;
+    let n_mels = cfg.n_mels as usize;
+    let n_mels_out = subsampled_mel_dim(n_mels);
+
+    let conv0_weight = gguf.dequantize_f32("enc.subsample.conv.0.weight")?;
+    let conv0_bias = gguf.dequantize_f32("enc.subsample.conv.0.bias")?;
+    let conv1_weight = gguf.dequantize_f32("enc.subsample.conv.1.weight")?;
+    let conv1_bias = gguf.dequantize_f32("enc.subsample.conv.1.bias")?;
+    let conv2_weight = gguf.dequantize_f32("enc.subsample.conv.2.weight")?;
+    let conv2_bias = gguf.dequantize_f32("enc.subsample.conv.2.bias")?;
+    let out_weight = gguf.dequantize_f32("enc.subsample.out.weight")?;
+    let out_bias = gguf.dequantize_f32("enc.subsample.out.bias")?;
+    let channels = conv0_bias.len();
+
+    let subsample = Subsample {
+        n_mels,
+        d_model: dm,
+        n_mels_out,
+        channels,
+        conv0_weight,
+        conv0_bias,
+        conv1_weight,
+        conv1_bias,
+        conv2_weight,
+        conv2_bias,
+        out_weight,
+        out_bias,
+    };
+
+    let mut blocks = Vec::with_capacity(cfg.n_layers as usize);
+    for l in 0..cfg.n_layers as usize {
+        blocks.push(load_block(gguf, l, dm, n_heads, conv_kernel)?);
+    }
+
+    let ln_post_gamma = gguf.dequantize_f32("enc.ln_post.weight")?;
+    let ln_post_beta = gguf.dequantize_f32("enc.ln_post.bias")?;
+
+    Ok(FastConformerEncoder {
+        cfg,
+        subsample,
+        blocks,
+        ln_post_gamma,
+        ln_post_beta,
+    })
 }
 
-pub struct FastConformerEncoder {
-    cfg: Config,
-}
+fn load_block(
+    gguf: &GgufFile,
+    l: usize,
+    dm: usize,
+    n_heads: usize,
+    conv_kernel: usize,
+) -> Result<ConformerBlock, String> {
+    let pfx = format!("enc.block.{l}");
+    let head_dim = dm / n_heads;
 
-impl FastConformerEncoder {
-    pub fn from_gguf(_gguf: &gguf_loader::GgufFile, cfg: Config) -> Result<Self, String> {
-        Ok(Self { cfg })
-    }
-
-    pub fn forward(&self, _mel: &MelSpectrogram) -> Result<EncoderOutput, String> {
-        Err("FastConformerEncoder::forward not yet implemented (parakeet)".into())
-    }
-
-    pub fn config(&self) -> &Config {
-        &self.cfg
-    }
+    let ff1 = FeedForward {
+        ln_gamma: gguf.dequantize_f32(&format!("{pfx}.ff1.ln.weight"))?,
+        ln_beta: gguf.dequantize_f32(&format!("{pfx}.ff1.ln.bias"))?,
+        fc1_weight: gguf.dequantize_f32(&format!("{pfx}.ff1.fc1.weight"))?,
+        fc1_bias: gguf.dequantize_f32(&format!("{pfx}.ff1.fc1.bias"))?,
+        fc2_weight: gguf.dequantize_f32(&format!("{pfx}.ff1.fc2.weight"))?,
+        fc2_bias: gguf.dequantize_f32(&format!("{pfx}.ff1.fc2.bias"))?,
+        d_model: dm,
+    };
+    let attn = MultiHeadAttention {
+        d_model: dm,
+        n_heads,
+        head_dim,
+        ln_gamma: gguf.dequantize_f32(&format!("{pfx}.attn.ln.weight"))?,
+        ln_beta: gguf.dequantize_f32(&format!("{pfx}.attn.ln.bias"))?,
+        q_weight: gguf.dequantize_f32(&format!("{pfx}.attn.q.weight"))?,
+        q_bias: gguf
+            .dequantize_f32(&format!("{pfx}.attn.q.bias"))
+            .unwrap_or_else(|_| vec![0.0; dm]),
+        k_weight: gguf.dequantize_f32(&format!("{pfx}.attn.k.weight"))?,
+        v_weight: gguf.dequantize_f32(&format!("{pfx}.attn.v.weight"))?,
+        v_bias: gguf
+            .dequantize_f32(&format!("{pfx}.attn.v.bias"))
+            .unwrap_or_else(|_| vec![0.0; dm]),
+        out_weight: gguf.dequantize_f32(&format!("{pfx}.attn.out.weight"))?,
+        out_bias: gguf
+            .dequantize_f32(&format!("{pfx}.attn.out.bias"))
+            .unwrap_or_else(|_| vec![0.0; dm]),
+        pos_weight: gguf.dequantize_f32(&format!("{pfx}.attn.pos.weight"))?,
+        pos_bias_u: gguf.dequantize_f32(&format!("{pfx}.attn.pos_bias_u"))?,
+        pos_bias_v: gguf.dequantize_f32(&format!("{pfx}.attn.pos_bias_v"))?,
+    };
+    let conv = ConvModule {
+        d_model: dm,
+        conv_kernel_size: conv_kernel,
+        ln_gamma: gguf.dequantize_f32(&format!("{pfx}.conv.ln.weight"))?,
+        ln_beta: gguf.dequantize_f32(&format!("{pfx}.conv.ln.bias"))?,
+        pw1_weight: gguf.dequantize_f32(&format!("{pfx}.conv.pw1.weight"))?,
+        pw1_bias: gguf
+            .dequantize_f32(&format!("{pfx}.conv.pw1.bias"))
+            .unwrap_or_else(|_| vec![0.0; 2 * dm]),
+        dw_weight: gguf.dequantize_f32(&format!("{pfx}.conv.dw.weight"))?,
+        dw_bias: gguf
+            .dequantize_f32(&format!("{pfx}.conv.dw.bias"))
+            .unwrap_or_else(|_| vec![0.0; dm]),
+        bn_gamma: gguf.dequantize_f32(&format!("{pfx}.conv.bn.weight"))?,
+        bn_beta: gguf.dequantize_f32(&format!("{pfx}.conv.bn.bias"))?,
+        bn_running_mean: gguf.dequantize_f32(&format!("{pfx}.conv.bn.running_mean"))?,
+        bn_running_var: gguf.dequantize_f32(&format!("{pfx}.conv.bn.running_var"))?,
+        pw2_weight: gguf.dequantize_f32(&format!("{pfx}.conv.pw2.weight"))?,
+        pw2_bias: gguf
+            .dequantize_f32(&format!("{pfx}.conv.pw2.bias"))
+            .unwrap_or_else(|_| vec![0.0; dm]),
+    };
+    let ff2 = FeedForward {
+        ln_gamma: gguf.dequantize_f32(&format!("{pfx}.ff2.ln.weight"))?,
+        ln_beta: gguf.dequantize_f32(&format!("{pfx}.ff2.ln.bias"))?,
+        fc1_weight: gguf.dequantize_f32(&format!("{pfx}.ff2.fc1.weight"))?,
+        fc1_bias: gguf.dequantize_f32(&format!("{pfx}.ff2.fc1.bias"))?,
+        fc2_weight: gguf.dequantize_f32(&format!("{pfx}.ff2.fc2.weight"))?,
+        fc2_bias: gguf.dequantize_f32(&format!("{pfx}.ff2.fc2.bias"))?,
+        d_model: dm,
+    };
+    Ok(ConformerBlock {
+        ff1,
+        attn,
+        conv,
+        ff2,
+        ln_post_gamma: gguf.dequantize_f32(&format!("{pfx}.ln_post.weight"))?,
+        ln_post_beta: gguf.dequantize_f32(&format!("{pfx}.ln_post.bias"))?,
+        d_model: dm,
+    })
 }

--- a/crates/parakeet-backend/src/lib.rs
+++ b/crates/parakeet-backend/src/lib.rs
@@ -1,54 +1,51 @@
 //! NVIDIA Parakeet TDT backend for any-stt.
 //!
-//! Target model: **parakeet-tdt-0.6b-v3** (FastConformer + TDT). 600M
-//! parameters, SentencePiece (8,192 tokens), 25 European languages.
+//! Target: **parakeet-tdt-0.6b-v3** — FastConformer (rel-pos) + TDT,
+//! 600M params, SentencePiece (8,192 tokens), 25 European languages.
 //!
 //! ⚠️ **Japanese is NOT supported by this model.** For Japanese workloads
-//! use [`reazonspeech-backend`] or kotoba-whisper via `whisper-backend`.
+//! use `reazonspeech-backend` (when Longformer lands) or kotoba-whisper
+//! via `whisper-backend`.
 //!
 //! Upstream: <https://huggingface.co/nvidia/parakeet-tdt-0.6b-v3>
 //!
-//! # Architecture
+//! # Pipeline
 //!
-//! Shares the FastConformer encoder with [`reazonspeech-backend`] (same
-//! `scripts/convert-nemo-to-gguf.py` produces GGUFs for both). The decoder
-//! is a **TDT (Token-Duration Transducer)** — an RNN-T generalization that
-//! emits a (token, duration) pair per step, skipping multiple encoder
-//! frames at once. Faster than RNN-T for the same accuracy.
+//! ```text
+//!   audio (f32, 16 kHz mono)
+//!     ↓ log_mel_spectrogram (fastconformer-core)
+//!   mel [time, n_mels]
+//!     ↓ FastConformerEncoder.forward
+//!   enc [time/8, d_model]
+//!     ↓ TdtDecoder.greedy_decode
+//!   token_ids [N]
+//!     ↓ SentencePieceTokenizer.detokenize
+//!   text
+//! ```
 //!
 //! # Status
 //!
-//! Skeleton. Decoder logic is independent from reazonspeech but the encoder
-//! forward is expected to share code once both crates pass CPU reference
-//! tests — at that point we extract `crates/fastconformer-core/`.
-//!
-//! # Decoder sketch (for when we come back to implement)
-//!
-//! ```text
-//! for each encoder frame t starting at t=0:
-//!     loop:
-//!         logits = joint(enc[t], pred_state)
-//!         token_logits = logits[:vocab]       // vocab_size + 1 for blank
-//!         dur_logits   = logits[vocab:]       // len(tdt_durations)
-//!         token = argmax(token_logits)
-//!         duration = tdt_durations[argmax(dur_logits)]
-//!         if token != blank:
-//!             emit token
-//!             pred_state = lstm_step(embedding(token), pred_state)
-//!         t += max(duration, 1)
-//! ```
+//! Encoder forward is wired (vanilla rel-pos in fastconformer-core).
+//! TDT decoder loader (`from_gguf`) is still stubbed, so transcribe
+//! returns NotImplemented from there. Tokenizer load is plumbed.
 
 pub mod decoder;
 pub mod encoder;
 
 use std::path::{Path, PathBuf};
+use std::time::Instant;
 
 use any_stt::{Backend, HardwareInfo, SttEngine, SttError, SttResult};
+use fastconformer_core::encoder::FastConformerEncoder;
+use fastconformer_core::{log_mel_spectrogram, SentencePieceTokenizer};
 
 pub use fastconformer_core::Config as ParakeetConfig;
 
 pub struct ParakeetEngine {
     model_path: PathBuf,
+    config: ParakeetConfig,
+    encoder: FastConformerEncoder,
+    tokenizer: Option<SentencePieceTokenizer>,
     hardware_info: HardwareInfo,
     backend: Backend,
     language: String,
@@ -66,20 +63,51 @@ impl ParakeetEngine {
                 path: model_path.to_path_buf(),
             });
         }
-        // Parakeet-TDT does not support Japanese / Korean / Chinese.
-        // We log but do not error — the caller may be using a custom fork.
         if matches!(language, "ja" | "ko" | "zh") {
             eprintln!(
-                "warning: parakeet-tdt-0.6b-v3 does not support language {language:?}; \
-                 consider reazonspeech-backend for Japanese"
+                "warning: parakeet-tdt-0.6b-v3 does not support language \
+                 {language:?}; consider reazonspeech-backend for Japanese"
             );
         }
+
+        let gguf = gguf_loader::GgufFile::open(model_path)
+            .map_err(|e| SttError::TranscriptionFailed(format!("gguf open: {e}")))?;
+        let config = ParakeetConfig::from_gguf(&gguf)
+            .map_err(|e| SttError::TranscriptionFailed(format!("config: {e}")))?;
+
+        let encoder = encoder::load(&gguf, config.clone())
+            .map_err(|e| SttError::TranscriptionFailed(format!("encoder load: {e}")))?;
+
+        // Tokenizer companion lives at "<model>.tokenizer.model" by
+        // convention (see `scripts/convert-nemo-to-gguf.py`).
+        let companion = model_path.with_extension("tokenizer.model");
+        let tokenizer = if companion.exists() {
+            Some(
+                SentencePieceTokenizer::load(&companion)
+                    .map_err(|e| SttError::TranscriptionFailed(format!("tokenizer: {e}")))?,
+            )
+        } else {
+            eprintln!(
+                "warning: tokenizer companion not found at {} — \
+                 transcribe will return token IDs instead of text",
+                companion.display()
+            );
+            None
+        };
+
         Ok(Self {
             model_path: model_path.to_path_buf(),
+            config,
+            encoder,
+            tokenizer,
             hardware_info,
             backend,
             language: language.to_string(),
         })
+    }
+
+    pub fn config(&self) -> &ParakeetConfig {
+        &self.config
     }
 }
 
@@ -88,13 +116,24 @@ impl SttEngine for ParakeetEngine {
         if audio.is_empty() {
             return Err(SttError::InvalidAudio("empty audio buffer".into()));
         }
-        // TODO(#N5): FastConformer encoder (shared w/ reazonspeech) → TDT decode.
+        let start = Instant::now();
+
+        let mel = log_mel_spectrogram(audio, &self.config);
+
+        let enc_out = self
+            .encoder
+            .forward(&mel.data, mel.n_frames)
+            .map_err(|e| SttError::TranscriptionFailed(format!("encoder forward: {e}")))?;
+
+        // TDT decoder needs a real GGUF loader (still stub). When it's
+        // wired up, replace this with `decoder.greedy_decode(&enc_out)`.
+        let _ = enc_out;
         Err(SttError::NotImplemented(format!(
-            "ParakeetEngine::transcribe not yet implemented — \
-             loaded {}, backend={:?}, language={}",
-            self.model_path.display(),
-            self.backend,
-            self.language,
+            "ParakeetEngine: encoder forward succeeded ({} frames @ {} d_model, {:.0}ms), \
+             but TDT decoder GGUF loader is not yet implemented",
+            mel.n_frames,
+            self.config.d_model,
+            start.elapsed().as_secs_f64() * 1000.0
         )))
     }
 

--- a/crates/reazonspeech-backend/src/decoder.rs
+++ b/crates/reazonspeech-backend/src/decoder.rs
@@ -24,9 +24,8 @@
 //! core for d=640) and loop-heavy — NPU offload does not pay off.
 
 use fastconformer_core::Config;
+use fastconformer_core::encoder::EncoderOutput;
 use gguf_loader::GgufFile;
-
-use crate::encoder::EncoderOutput;
 
 /// One LSTM layer.
 struct LstmLayer {

--- a/crates/reazonspeech-backend/src/encoder.rs
+++ b/crates/reazonspeech-backend/src/encoder.rs
@@ -1,96 +1,160 @@
-//! FastConformer encoder (NeMo variant, Longformer local + global attention).
+//! ReazonSpeech encoder wrapper.
 //!
-//! Each encoder block follows the Conformer pattern with two feed-forward
-//! "macaron" halves around attention and convolution:
-//!
-//! ```text
-//! x ──►┐
-//!      ▼
-//!    ff1   → 0.5 × FFN (pre-LN, swish, linear, dropout)
-//!      │
-//!      ▼
-//!    attn  → Longformer rel-pos (local window 256, 1 global token)
-//!      │
-//!      ▼
-//!    conv  → pointwise / depthwise / GLU / batchnorm (kernel 9)
-//!      │
-//!      ▼
-//!    ff2   → 0.5 × FFN
-//!      │
-//!      ▼
-//!   ln_post
-//! ```
-//!
-//! ## Status
-//! Stub. The structures are defined so that QNN / Vulkan graph builders in
-//! `qnn-backend` and `nnapi-backend` can target them, but the CPU ggml
-//! implementation is not yet wired.
-//!
-//! ## NPU offload plan
-//! - `attn.q/k/v/out` Linear projections → NPU MatMul (INT8 preferred)
-//! - `conv.pw1/dw/pw2` Convolutions → NPU Conv1d (target layers with
-//!   depth < 16 for NNAPI)
-//! - `ff1/ff2.fc1/fc2` → NPU MatMul
-//! - LayerNorm + softmax + residuals → CPU
-//! - Positional bias (pos_bias_u/v) → CPU (small)
+//! Re-exports `fastconformer_core::encoder::FastConformerEncoder` and adds
+//! a thin `from_gguf` loader specific to the reazonspeech-nemo-v2 tensor
+//! naming. The encoder forward itself is shared with parakeet-backend.
 
+use fastconformer_core::encoder::{
+    ConformerBlock, ConvModule, FastConformerEncoder, FeedForward, MultiHeadAttention,
+    Subsample, subsampled_mel_dim,
+};
+pub use fastconformer_core::encoder::EncoderOutput;
 use fastconformer_core::Config;
-use fastconformer_core::MelSpectrogram;
+use gguf_loader::GgufFile;
 
-/// Encoder output: acoustic representation ready for the RNN-T joint network.
+/// Build a FastConformer encoder from a reazonspeech-nemo-v2 GGUF file.
 ///
-/// Layout: `[n_frames_after_subsample, d_model]` row-major f32.
-pub struct EncoderOutput {
-    pub data: Vec<f32>,
-    pub n_frames: usize,
-    pub d_model: usize,
+/// Returns a fully-wired encoder if all expected tensors are present.
+/// Tensor naming follows `scripts/convert-nemo-to-gguf.py`'s rename
+/// table.
+pub fn load(gguf: &GgufFile, cfg: Config) -> Result<FastConformerEncoder, String> {
+    let dm = cfg.d_model as usize;
+    let n_heads = cfg.n_heads as usize;
+    let conv_kernel = cfg.conv_kernel_size as usize;
+    let n_mels = cfg.n_mels as usize;
+    let n_mels_out = subsampled_mel_dim(n_mels);
+
+    // --- Subsample weights ---
+    let conv0_weight = gguf.dequantize_f32("enc.subsample.conv.0.weight")?;
+    let conv0_bias = gguf.dequantize_f32("enc.subsample.conv.0.bias")?;
+    let conv1_weight = gguf.dequantize_f32("enc.subsample.conv.1.weight")?;
+    let conv1_bias = gguf.dequantize_f32("enc.subsample.conv.1.bias")?;
+    let conv2_weight = gguf.dequantize_f32("enc.subsample.conv.2.weight")?;
+    let conv2_bias = gguf.dequantize_f32("enc.subsample.conv.2.bias")?;
+    let out_weight = gguf.dequantize_f32("enc.subsample.out.weight")?;
+    let out_bias = gguf.dequantize_f32("enc.subsample.out.bias")?;
+
+    // Channel count is encoded in conv0_bias length.
+    let channels = conv0_bias.len();
+
+    let subsample = Subsample {
+        n_mels,
+        d_model: dm,
+        n_mels_out,
+        channels,
+        conv0_weight,
+        conv0_bias,
+        conv1_weight,
+        conv1_bias,
+        conv2_weight,
+        conv2_bias,
+        out_weight,
+        out_bias,
+    };
+
+    // --- Conformer blocks ---
+    let mut blocks = Vec::with_capacity(cfg.n_layers as usize);
+    for l in 0..cfg.n_layers as usize {
+        let block = load_block(gguf, l, dm, n_heads, conv_kernel)?;
+        blocks.push(block);
+    }
+
+    let ln_post_gamma = gguf.dequantize_f32("enc.ln_post.weight")?;
+    let ln_post_beta = gguf.dequantize_f32("enc.ln_post.bias")?;
+
+    Ok(FastConformerEncoder {
+        cfg,
+        subsample,
+        blocks,
+        ln_post_gamma,
+        ln_post_beta,
+    })
 }
 
-/// FastConformer encoder handle.
-///
-/// Holds dequantized weights + any NPU graph handles. Thread-safe as long
-/// as `forward` is not called concurrently on the same instance.
-pub struct FastConformerEncoder {
-    cfg: Config,
-    // TODO(#N4): fields for weights + optional NPU graph handle
-}
+fn load_block(
+    gguf: &GgufFile,
+    l: usize,
+    dm: usize,
+    n_heads: usize,
+    conv_kernel: usize,
+) -> Result<ConformerBlock, String> {
+    let pfx = format!("enc.block.{l}");
+    let head_dim = dm / n_heads;
 
-impl FastConformerEncoder {
-    /// Build an encoder from the GGUF model.
-    ///
-    /// # Errors
-    /// Returns a descriptive error if expected tensors are missing.
-    pub fn from_gguf(
-        _gguf: &gguf_loader::GgufFile,
-        cfg: Config,
-    ) -> Result<Self, String> {
-        // TODO(#N4): dequantize all encoder.* tensors and cache.
-        //   For each layer L in 0..cfg.n_layers, load:
-        //     - enc.block.L.ff1.{ln,fc1,fc2}.{weight,bias}
-        //     - enc.block.L.attn.{ln,q,k,v,out,pos,pos_bias_u,pos_bias_v}
-        //     - enc.block.L.conv.{ln,pw1,dw,bn,pw2}.{weight,bias,running_*}
-        //     - enc.block.L.ff2.{ln,fc1,fc2}.{weight,bias}
-        //     - enc.block.L.ln_post.{weight,bias}
-        //   Plus enc.subsample.*, enc.pos.pe, enc.ln_post.*
-        Ok(Self { cfg })
-    }
+    let ff1 = FeedForward {
+        ln_gamma: gguf.dequantize_f32(&format!("{pfx}.ff1.ln.weight"))?,
+        ln_beta: gguf.dequantize_f32(&format!("{pfx}.ff1.ln.bias"))?,
+        fc1_weight: gguf.dequantize_f32(&format!("{pfx}.ff1.fc1.weight"))?,
+        fc1_bias: gguf.dequantize_f32(&format!("{pfx}.ff1.fc1.bias"))?,
+        fc2_weight: gguf.dequantize_f32(&format!("{pfx}.ff1.fc2.weight"))?,
+        fc2_bias: gguf.dequantize_f32(&format!("{pfx}.ff1.fc2.bias"))?,
+        d_model: dm,
+    };
 
-    /// Run the encoder on a mel spectrogram.
-    pub fn forward(&self, _mel: &MelSpectrogram) -> Result<EncoderOutput, String> {
-        // TODO(#N4): implement forward pass.
-        //   1. Subsampling (striding conv2d ×8) → [T/8, d_model]
-        //   2. Add positional encoding (relative)
-        //   3. For each block:
-        //      a. ff1 half-residual
-        //      b. multi-head attention (Longformer local + global)
-        //      c. conv module
-        //      d. ff2 half-residual
-        //      e. ln_post
-        //   4. Final layernorm
-        Err("FastConformerEncoder::forward not yet implemented".into())
-    }
+    let attn = MultiHeadAttention {
+        d_model: dm,
+        n_heads,
+        head_dim,
+        ln_gamma: gguf.dequantize_f32(&format!("{pfx}.attn.ln.weight"))?,
+        ln_beta: gguf.dequantize_f32(&format!("{pfx}.attn.ln.bias"))?,
+        q_weight: gguf.dequantize_f32(&format!("{pfx}.attn.q.weight"))?,
+        q_bias: gguf
+            .dequantize_f32(&format!("{pfx}.attn.q.bias"))
+            .unwrap_or_else(|_| vec![0.0; dm]),
+        k_weight: gguf.dequantize_f32(&format!("{pfx}.attn.k.weight"))?,
+        v_weight: gguf.dequantize_f32(&format!("{pfx}.attn.v.weight"))?,
+        v_bias: gguf
+            .dequantize_f32(&format!("{pfx}.attn.v.bias"))
+            .unwrap_or_else(|_| vec![0.0; dm]),
+        out_weight: gguf.dequantize_f32(&format!("{pfx}.attn.out.weight"))?,
+        out_bias: gguf
+            .dequantize_f32(&format!("{pfx}.attn.out.bias"))
+            .unwrap_or_else(|_| vec![0.0; dm]),
+        pos_weight: gguf.dequantize_f32(&format!("{pfx}.attn.pos.weight"))?,
+        pos_bias_u: gguf.dequantize_f32(&format!("{pfx}.attn.pos_bias_u"))?,
+        pos_bias_v: gguf.dequantize_f32(&format!("{pfx}.attn.pos_bias_v"))?,
+    };
 
-    pub fn config(&self) -> &Config {
-        &self.cfg
-    }
+    let conv = ConvModule {
+        d_model: dm,
+        conv_kernel_size: conv_kernel,
+        ln_gamma: gguf.dequantize_f32(&format!("{pfx}.conv.ln.weight"))?,
+        ln_beta: gguf.dequantize_f32(&format!("{pfx}.conv.ln.bias"))?,
+        pw1_weight: gguf.dequantize_f32(&format!("{pfx}.conv.pw1.weight"))?,
+        pw1_bias: gguf
+            .dequantize_f32(&format!("{pfx}.conv.pw1.bias"))
+            .unwrap_or_else(|_| vec![0.0; 2 * dm]),
+        dw_weight: gguf.dequantize_f32(&format!("{pfx}.conv.dw.weight"))?,
+        dw_bias: gguf
+            .dequantize_f32(&format!("{pfx}.conv.dw.bias"))
+            .unwrap_or_else(|_| vec![0.0; dm]),
+        bn_gamma: gguf.dequantize_f32(&format!("{pfx}.conv.bn.weight"))?,
+        bn_beta: gguf.dequantize_f32(&format!("{pfx}.conv.bn.bias"))?,
+        bn_running_mean: gguf.dequantize_f32(&format!("{pfx}.conv.bn.running_mean"))?,
+        bn_running_var: gguf.dequantize_f32(&format!("{pfx}.conv.bn.running_var"))?,
+        pw2_weight: gguf.dequantize_f32(&format!("{pfx}.conv.pw2.weight"))?,
+        pw2_bias: gguf
+            .dequantize_f32(&format!("{pfx}.conv.pw2.bias"))
+            .unwrap_or_else(|_| vec![0.0; dm]),
+    };
+
+    let ff2 = FeedForward {
+        ln_gamma: gguf.dequantize_f32(&format!("{pfx}.ff2.ln.weight"))?,
+        ln_beta: gguf.dequantize_f32(&format!("{pfx}.ff2.ln.bias"))?,
+        fc1_weight: gguf.dequantize_f32(&format!("{pfx}.ff2.fc1.weight"))?,
+        fc1_bias: gguf.dequantize_f32(&format!("{pfx}.ff2.fc1.bias"))?,
+        fc2_weight: gguf.dequantize_f32(&format!("{pfx}.ff2.fc2.weight"))?,
+        fc2_bias: gguf.dequantize_f32(&format!("{pfx}.ff2.fc2.bias"))?,
+        d_model: dm,
+    };
+
+    Ok(ConformerBlock {
+        ff1,
+        attn,
+        conv,
+        ff2,
+        ln_post_gamma: gguf.dequantize_f32(&format!("{pfx}.ln_post.weight"))?,
+        ln_post_beta: gguf.dequantize_f32(&format!("{pfx}.ln_post.bias"))?,
+        d_model: dm,
+    })
 }

--- a/crates/reazonspeech-backend/src/lib.rs
+++ b/crates/reazonspeech-backend/src/lib.rs
@@ -78,14 +78,17 @@ impl SttEngine for ReazonSpeechEngine {
         if audio.is_empty() {
             return Err(SttError::InvalidAudio("empty audio buffer".into()));
         }
-        // TODO(#N4): mel → encoder → decoder → tokenizer pipeline.
-        Err(SttError::NotImplemented(format!(
-            "ReazonSpeechEngine::transcribe not yet implemented — \
-             loaded {}, backend={:?}, language={}",
-            self.model_path.display(),
-            self.backend,
-            self.language,
-        )))
+        // ReazonSpeech v2 uses Longformer attention which the
+        // fastconformer-core encoder doesn't yet implement. Surface a
+        // clear error so callers know what's missing rather than letting
+        // the encoder fall through to the vanilla rel-pos path.
+        Err(SttError::NotImplemented(
+            "ReazonSpeech transcribe requires Longformer (rel_pos_local_attn) \
+             attention, which fastconformer-core does not yet implement. \
+             The full mel → encoder → decoder → tokenizer pipeline is wired \
+             and will activate once Longformer is added."
+                .into(),
+        ))
     }
 
     fn is_ready(&self) -> bool {
@@ -156,7 +159,7 @@ mod tests {
         let audio = vec![0.0_f32; 16000];
         match engine.transcribe(&audio) {
             Err(SttError::NotImplemented(msg)) => {
-                assert!(msg.contains("ReazonSpeechEngine"));
+                assert!(msg.contains("Longformer"), "got: {msg}");
             }
             Err(e) => panic!("expected NotImplemented, got {e}"),
             Ok(_) => panic!("expected NotImplemented, got Ok"),


### PR DESCRIPTION
## Summary

Closes the gap between the encoder primitives that landed in #11 and a working end-to-end forward pass. Adds ~1200 lines of pure-Rust f32 reference implementation of every Conformer module (FF, Conv, MHA, Subsample, Block) plus the Encoder composition, then wires them through both backend crates.

### Encoder modules (fastconformer-core/src/encoder/)
- **ff.rs** — macaron-half feed-forward (LN → fc1 → swish → fc2 → 0.5 × residual)
- **conv_module.rs** — LN → PW1 → GLU → DW conv1d → BN → swish → PW2 → residual
- **subsample.rs** — Conv2d ×3 stride 2 + Linear (NeMo `subsampling="striding"`)
- **attention.rs** — Multi-head rel-pos attention (Transformer-XL Q+u/Q+v bias formulation, sinusoidal pos emb)
- **block.rs** — ConformerBlock = FF1 → MHA → Conv → FF2 → LN_post
- **encoder/mod.rs** — `FastConformerEncoder` integration

### Wire-up
- `reazonspeech_backend::encoder::load(gguf, cfg)` and `parakeet_backend::encoder::load(gguf, cfg)` build the encoder from a converted GGUF.
- `ParakeetEngine::new` eagerly loads encoder + tokenizer companion. `transcribe()` runs mel → encoder.forward end-to-end and reports NotImplemented at the TDT decoder GGUF loader seam (the only remaining stub).
- `ReazonSpeechEngine::transcribe` returns a clear Longformer-not-yet-implemented error rather than silently using rel-pos.

## Test counts

Workspace lib tests: **128 → 163** (+35 new). All green locally.

## Still external

- Longformer attention variant (reazonspeech enabling)
- TDT decoder GGUF loader — needs real `.nemo` tensor names
- Numerical validation against NeMo (run `scripts/dump-nemo-fixtures.py`)
- NPU offload graphs
- Qwen3-ASR backend (#N6)
- Android device benchmark

## Test plan

- [ ] CI: Linux + macOS + iOS + Android + Windows + Linux/Windows CUDA (7 jobs)
- [ ] Manual: `cargo test --workspace` reports 0 failures (163 lib tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)