### PR TITLE
docs: mel validation status + roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,8 @@ whisper-backend = { path = "crates/whisper-backend" }
 
 ## Supported Models
 
+### Whisper family (production-ready)
+
 All Whisper-architecture models in ggml/GGUF format.
 
 | Model | Params | Size (F16) | Quality | Notes |
@@ -233,6 +235,28 @@ All Whisper-architecture models in ggml/GGUF format.
 | large-v3-turbo | 809M | 1.6 GB | Near-best | Speed+quality |
 | kotoba-v2.0 | 1550M | 1.4 GB (F16) | Best Japanese | Distilled decoder |
 
+### NeMo FastConformer family (in development)
+
+| Model | Params | Status | Notes |
+|-------|--------|--------|-------|
+| reazonspeech-nemo-v2 (`reazonspeech-backend`) | 619M | mel ✅ NeMo-compat, encoder forward ⚠️ drift | Japanese; FastConformer + Longformer attn + RNN-T |
+| parakeet-tdt-0.6b-v3 (`parakeet-backend`)     | 600M | skeleton ✅, weights not yet downloaded         | 25 European languages; FastConformer + rel-pos + TDT |
+
+The `mel` preprocessor is bit-equivalent to NeMo's
+`AudioToMelSpectrogramPreprocessor` (max_abs vs reference: **8.9e-5** on
+real Japanese audio). Stage-by-stage validation harness in
+`crates/fastconformer-core/tests/layer_reference.rs`. The encoder body
+runs end-to-end on real GGUFs but produces drifted output — fix is
+tracked under `#N9` (see `crates/fastconformer-core/README.md`).
+
+### Qwen3-ASR family (planned)
+
+| Model | Status |
+|-------|--------|
+| Qwen3-ASR-1.7B (`qwen-asr-backend`) | runtime decided (`llama-cpp-2` + `mtmd`); skeleton only |
+
+See [docs/qwen-asr-runtime-decision.md](docs/qwen-asr-runtime-decision.md).
+
 ### GGUF Conversion
 
 ```bash
@@ -241,6 +265,12 @@ python3 scripts/convert-to-gguf.py tiny.en output.gguf
 
 # Kotoba (HuggingFace) → ggml
 python3 scripts/convert-kotoba-to-ggml.py
+
+# NeMo FastConformer (.nemo) → GGUF v3
+python3 scripts/convert-nemo-to-gguf.py model.nemo output.gguf
+
+# Validate the mel preprocessor matches NeMo numerics
+python3 scripts/validate-mel.py --audio audio.wav --out mel_ref.npy
 ```
 
 ## Tests

--- a/crates/fastconformer-core/README.md
+++ b/crates/fastconformer-core/README.md
@@ -1,0 +1,123 @@
+# fastconformer-core
+
+Shared FastConformer ASR primitives used by both
+`reazonspeech-backend` (Japanese, Longformer + RNN-T) and
+`parakeet-backend` (English / European, rel-pos + TDT).
+
+## What's in here
+
+| Module | Purpose |
+|--------|---------|
+| `mel.rs`            | NeMo-compatible log-mel filterbank |
+| `tokenizer.rs`      | SentencePiece detokenizer (decode-only) |
+| `config.rs`         | GGUF metadata → typed `Config` |
+| `encoder/ops.rs`    | Linear, LayerNorm, Swish, GLU, softmax, BN primitives |
+| `encoder/subsample.rs` | Striding (3×Conv2d) + dw_striding (Conv2d + 2×DW+PW) |
+| `encoder/attention.rs` | MHA with rel-pos + optional Longformer mode |
+| `encoder/conv_module.rs` | Pointwise + depthwise Conv1d + GLU + BN |
+| `encoder/ff.rs`     | Conformer macaron-half feed-forward |
+| `encoder/block.rs`  | Full ConformerBlock |
+| `encoder/mod.rs`    | `FastConformerEncoder` integration |
+
+## Mel preprocessor — NeMo numerical equivalence
+
+`log_mel_spectrogram` matches NeMo's `AudioToMelSpectrogramPreprocessor`
+to within float32 precision. Validated stage-by-stage against
+torchaudio (which NeMo wraps internally) using the
+`scripts/validate-mel.py --dump-intermediates` reference dumps.
+
+| Stage | `max_abs` vs torchaudio | Notes |
+|-------|------------------------|-------|
+| pre-emphasis (α=0.97)              | **0.0**       | `y[n] = x[n] - α·x[n-1]` |
+| Hann window (periodic)             | **formula**   | `0.5·(1 − cos(2π·i/n))`, n=400 |
+| frame extract (after reflect pad)  | **3.0e-8**    | `center=True`, `pad_mode="reflect"` |
+| mel filterbank (slaney scale)      | **0.0**       | matches `melscale_fbanks(norm="slaney", mel_scale="slaney")` |
+| power spectrum, frame 0            | **0.0**       | silent region, log(1e-5) |
+| power spectrum, frame 100          | **9.5e-7**    | active region |
+| log(mel + 1e-5) pre-normalize      | **2.9e-4**    | full sequence |
+| post-normalize (per-feature)       | **8.9e-5**    | full sequence vs NeMo target |
+
+Each layer has a dedicated `#[test]` in
+`tests/layer_reference.rs` that auto-skips when the
+`scripts/validate-mel.py --dump-intermediates` outputs aren't present
+under `tests/fixtures/<model>/debug/` (the path is gitignored — fixtures
+are developer-local).
+
+### The bug that mattered most
+
+Initial Rust mel had `max_abs = 3.16` vs NeMo. After fixing window-
+inside-FFT placement (torch.stft pads `win_length`-long Hann to the
+**center** of the `n_fft` buffer with leading + trailing zeros, not
+to position 0 with trailing zeros), `max_abs` dropped to 8.9e-5 — bit-
+equivalent for inference purposes.
+
+Run the validation locally:
+
+```sh
+# one-time deps
+python -m venv /tmp/anyvenv
+/tmp/anyvenv/bin/pip install torch torchaudio soundfile numpy
+
+# regenerate references
+/tmp/anyvenv/bin/python scripts/validate-mel.py \
+    --audio third-party/whisper.cpp/samples/japanese_test.wav \
+    --out crates/fastconformer-core/tests/fixtures/reazonspeech-nemo-v2/mel_ja.npy \
+    --dump-intermediates
+
+# run all comparisons (the strict #[test]'s are NOT #[ignore]'d)
+cargo test -p fastconformer-core --test layer_reference
+# the post-normalize comparison runs only with --ignored:
+cargo test -p fastconformer-core --test layer_reference \
+    mel_matches_nemo_reference -- --ignored
+```
+
+## Encoder forward — known drift (not yet validated)
+
+The encoder body (subsample → N × ConformerBlock → final LN) runs to
+completion on the real `reazonspeech-nemo-v2` GGUF, but its outputs
+do **not** numerically match NeMo. Symptom: greedy RNN-T decoding
+produces gibberish (a few correct Japanese fragments mixed with long
+runs of repeated tokens).
+
+Status:
+- mel input is now NeMo-equivalent (above)
+- Conformer modules are structurally correct (zero-input passes through
+  cleanly, lib unit tests cover identity / bias-only paths)
+- Numerical drift must be in one or more of: dw_striding subsample,
+  rel-pos attention math (Q+u/Q+v bias and rel-shift), conv module
+  (BN + GLU axis), or the per-block residual scaling
+
+This is the next #N9 milestone. Approach:
+1. Build a minimal Python encoder that loads `model_weights.ckpt`
+   directly (no nemo-toolkit, since it's incompatible with Python 3.14)
+2. Dump per-layer outputs as `.npy`
+3. Add stage-by-stage comparison tests in
+   `tests/layer_reference.rs` (same pattern as the mel layer harness)
+4. Locate and fix the first stage where `max_abs > 1e-3`
+
+## Tokenizer
+
+`SentencePieceTokenizer` parses the SentencePiece `.model` proto3 file
+shipped alongside each `.nemo`. Decode-only (no encode); avoids the
+1 MB C++ sentencepiece binding and the platform compatibility concerns
+that come with it. Tested against synthetic models in
+`tokenizer.rs::tests`.
+
+## Encoder primitives
+
+`encoder/ops.rs` provides scalar f32 implementations of the building
+blocks that compose the Conformer block:
+
+| Function | Purpose |
+|----------|---------|
+| `matvec_add`             | `out += W · x` (Linear without bias) |
+| `linear`                 | `y = W · x + b` |
+| `layer_norm` / `layer_norm_rows` | last-dim LN, optionally per-row |
+| `swish_inplace`          | SiLU activation |
+| `glu_channels`           | GLU split-and-gate |
+| `softmax_inplace`        | numerically stable max-shifted softmax |
+| `batch_norm_1d_inference` | inference-only BN with running stats |
+
+Each has unit tests covering identity / zero / bias-only / overflow-
+adjacent inputs. These are the building blocks for the full encoder
+forward in `encoder/{block,conv_module,attention,subsample,ff}.rs`.


### PR DESCRIPTION
## Summary

Documentation-only PR capturing the state achieved in #14: mel preprocessor is bit-equivalent to NeMo (max_abs **8.9e-5** on real Japanese audio), encoder downstream still drifts.

## Changes

- **`crates/fastconformer-core/README.md`** — new file. Documents:
  - Module layout
  - The full mel validation table (preemph 0.0, hann formula match, frame extract 3e-8, mel filterbank 0.0, power frame 0/100 0.0/9.5e-7, log_mel pre/post-normalize 2.9e-4/8.9e-5)
  - The bug-fix that mattered (centered window placement inside the n_fft buffer)
  - Steps to reproduce the validation
  - Encoder downstream status + `#N9` plan
- **`README.md`** — supported-models section now lists three families:
  - Whisper (production)
  - NeMo FastConformer (in development; mel ✅, encoder ⚠️)
  - Qwen3-ASR (planned; runtime decided)
- Added pointers to `convert-nemo-to-gguf.py` and `validate-mel.py`.

No code changes. No test count change.

## Test plan

- [ ] CI: 7 jobs (Linux + macOS + iOS + Android + Windows + Linux/Windows CUDA)
- Trivial — only README/markdown changes